### PR TITLE
add miscellanea/hacks

### DIFF
--- a/miscellanea/README.md
+++ b/miscellanea/README.md
@@ -16,4 +16,4 @@ Miscellaneous materials for TeXmacs
   * A plugin for correcting spelling, grammar and typography errors in TeXmacs documents using LanguageTool ([dir](./languagetool))
   * the `post-modern` icon collection ([dir](./post-modern-icons))
   * A package to produce publication lists sorted by year ([dir](./tm-publist))
-  
+  * A scheme module to (partially) implement Emacs' `cl-letf`. To use it, just place the `hacks` dir in your `TEXMACS_HOME_PATH/progs` and open the included doc `cl-letf-test.tm` ([dir](./hacks))

--- a/miscellanea/hacks/cl-letf-test.tm
+++ b/miscellanea/hacks/cl-letf-test.tm
@@ -1,0 +1,140 @@
+<TeXmacs|2.1.4>
+
+<style|<tuple|article|preview-ref|smart-ref|framed-theorems|padded-paragraphs|number-long-article>>
+
+<\body>
+  <\hide-preamble>
+    <assign|cmt|<macro|body|<with|color|blue|<arg|body>>>>
+  </hide-preamble>
+
+  <cmt|There are some texts,> and formulas
+
+  <\equation>
+    sin x=exp<around*|(|-y|)>
+  </equation>
+
+  <hrule>
+
+  Below are how macros <code*|cl-letf> and <code*|with-display-arguments> are
+  used. Specifically, <code*|cl-letf> reload functions locally and
+  <code*|with-display-arguments> is a specialization of the former which
+  prints arguments of specified functions.
+
+  <\session|scheme|default>
+    <\input|Scheme] >
+      (use-modules (hacks cl-letf))
+    </input>
+
+    <\unfolded-io|Scheme] >
+      (begin
+
+      \ \ (define (g x) (apply * x))
+
+      \ \ (define (f x) (apply + x))
+
+      \ \ (list
+
+      \ \ \ (f (list 1 2 3 (g (list 5 6))))
+
+      \ \ \ (with-display-arguments ((f) (g))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (f (list 1 2 3 (g
+      (list 5 6)))))
+
+      \ \ \ (cl-letf ((f (let ((f f)) (lambda (x) (* (f x) 2))))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ \ (g (let ((g g)) (lambda (x) (+ (g x) 1)))))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ (f (list 1 2 3 (g (list 5 6)))))))
+    <|unfolded-io>
+      (36 36 74)
+    </unfolded-io>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
+
+  I include two simple functions <code*|my-func-a> and <code*|my-func-b> to
+  test the moduled version
+
+  <\session|scheme|default>
+    <\unfolded-io|Scheme] >
+      (begin
+
+      \ \ (define my-func-a-1
+
+      \ \ \ \ (let ((f (module-ref (resolve-module '(hacks cl-letf))
+      'my-func-a)))
+
+      \ \ \ \ \ \ (lambda (x) (* (f x) x))))
+
+      \ \ (list
+
+      \ \ \ (my-func-b 3)
+
+      \ \ \ (cl-letf ((my-func-a my-func-a-1 (hacks cl-letf)))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ (my-func-b 3))
+
+      \ \ \ (with-display-arguments ((my-func-a (hacks cl-letf)))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (my-func-b 3))))
+    <|unfolded-io>
+      (4 12 4)
+    </unfolded-io>
+  </session>
+
+  Now we utilize them for some practical tasks. Suppose you are want to
+  prevent some elements from being exported to latex, e.g.
+  <verbatim|\<less\>cmt\|There are some texts\<gtr\>> in the beginning of
+  this document, under the construct <verbatim|cmt>. First you need to search
+  for the correct function to modify. After looking through dir
+  <verbatim|progs/latex>, there are two suspicious functions,
+  <verbatim|tmtex> and <verbatim|texout>. Utilizing the macro
+  <verbatim|with-display-arguments>, we hijack to force printing their
+  arguments and find that <verbatim|texout> is the one in control of printing
+  step of buffer export.
+
+  We then \Padvice\Q it to not do anything for the construct <verbatim|cmt>.
+  Now you find the exported latex file has no <verbatim|cmt> in place.
+
+  <\session|scheme|default>
+    <\input|Scheme] >
+      (with-display-arguments ((tmtex-pre (convert latex tmtex)))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (export-buffer
+      (string-\<gtr\>url "/tmp/a.tex")))
+    </input>
+
+    <\input|Scheme] >
+      (with-display-arguments ((texout (convert latex texout)))
+
+      \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ \ (export-buffer
+      (string-\<gtr\>url "/tmp/a.tex")))
+    </input>
+
+    <\input|Scheme] >
+      (cl-letf ((texout (let ((texout texout)) (lambda (x) (unless (tm-func?
+      x 'cmt) (texout x))))))
+
+      \ \ \ \ \ \ \ \ \ (export-buffer (string-\<gtr\>url "/tmp/a.tex")))
+    </input>
+
+    <\input|Scheme] >
+      \;
+    </input>
+  </session>
+
+  These instruments make it convenient to modify the way <TeXmacs> behaves.
+</body>
+
+<\initial>
+  <\collection>
+    <associate|page-height|auto>
+    <associate|page-medium|paper>
+    <associate|page-type|letter>
+    <associate|page-width|auto>
+    <associate|preamble|false>
+  </collection>
+</initial>

--- a/miscellanea/hacks/cl-letf.scm
+++ b/miscellanea/hacks/cl-letf.scm
@@ -1,0 +1,82 @@
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; MODULE      : cl-letf.scm
+;; DESCRIPTION : Partial implementation of cl-letf in (TeXmacs' guile) scheme
+;; COPYRIGHT   : (C) 2025 Zhengfei Hu
+;;
+;; This software falls under the GNU general public license version 3 or later.
+;; It comes WITHOUT ANY WARRANTY WHATSOEVER. For details, see the file LICENSE
+;; in the root directory or <http://www.gnu.org/licenses/gpl-3.0.html>.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(texmacs-module (hacks cl-letf))
+
+;; Due to the lack of setf mechanism, it's not economic to do much beyond
+;; locally setting values of symbols and definitions of functions, which is the
+;; only thing we tend to do here.
+
+
+;; Inputs and outputs are symbol/form
+(define (ref-form sym mod)
+  (if (null? mod)
+      sym
+      `(module-ref (resolve-module ',(car mod)) ',sym)))
+
+(define (set-form sym val mod)
+  (if (null? mod)
+      `(set! ,sym ,val)
+      `(module-set! (resolve-module ',(car mod)) ',sym ,val)))
+
+
+(define (cl-letf-impl triples pre post olds body . syms)
+  (when (null? syms)
+    (set! syms (list (gensym) (gensym))))
+  ;; those syms implement hygienic macros manually
+  (let ((sym1 (car syms))
+        (sym2 (cadr syms) ))
+    (if (not (null? triples))
+        (let* ((c (car triples))
+               (fn (car c))
+               (def (eval (cadr c)))       ; assuming guile<1.6 syntax, to which TeXmacs already made compatible
+               (mod (cddr c))
+               (e1 (cons (set-form fn def mod) pre))
+               (e2 (cons (set-form fn `(car ,sym1) mod)
+                         (cons (set-form sym1 `(cdr ,sym1) '()) post)))
+               (e3 (cons (ref-form fn mod) olds)))              ; olds saves a list of forms that capture old definitions at runtime
+          (cl-letf-impl (cdr triples) e1 e2 e3 body sym1 sym2))
+        `(let ((,sym1 (list ,@olds)) (,sym2 '()))
+           ,@pre
+           (set! ,sym2 (begin ,@body))
+           ,@post
+           ,sym2))))
+
+
+(tm-define-macro (cl-letf triples . body)
+  ;; triples of: (fn def mod)
+  (cl-letf-impl triples '() '() '() body))
+
+;; ============================== with-display-arguments
+(define (wrap-display pair)
+  (let ((f (if (null? (cdr pair))
+               (eval (car pair))
+               (eval `(module-ref (resolve-module ',(cadr pair)) ',(car pair))))))
+    (lambda (. x)
+      (display* "[" pair "] " x "\n")
+      (apply f x))))
+
+(define (wrap-triple pair)
+  (cons (car pair)
+        (cons (wrap-display pair) (cdr pair))))
+
+(tm-define-macro (with-display-arguments pairs . body)
+  ;; pairs of (fn mod)
+  (cl-letf-impl (map wrap-triple pairs) '() '() '() body))
+
+;; ============================== test functions; for module-ref
+(define (my-func-a x)
+  (+ x 1))
+
+(tm-define (my-func-b x)
+  (my-func-a x))


### PR DESCRIPTION
I added a module `hacks/cl-letf` to provide a convenient and non-intrusive way to hack scheme part of TeXmacs. Some examples are provided.